### PR TITLE
Add support for float16 matmul

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blas"
-version = "0.22.0"
+version = "0.22.1"
 license = "Apache-2.0/MIT"
 authors = [
     "Andrew Straw <strawman@astraw.com>",
@@ -19,11 +19,15 @@ keywords = ["linear-algebra"]
 
 [dependencies]
 libc = "0.2"
+half = {version="2.3.1", optional=true}
 
 [dependencies.num-complex]
 version = "0.4"
 default-features = false
 
 [dependencies.blas-sys]
-version = "0.7"
+version = "0.7.2"
 default-features = false
+
+[features]
+half = ["blas-sys/half", "dep:half"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2822,3 +2822,37 @@ pub unsafe fn ztrsm(
         &ldb,
     )
 }
+
+#[cfg(feature = "half")]
+#[inline]
+pub unsafe fn hgemm(
+    transa: u8,
+    transb: u8,
+    m: i32,
+    n: i32,
+    k: i32,
+    alpha: half::f16,
+    a: &[half::f16],
+    lda: i32,
+    b: &[half::f16],
+    ldb: i32,
+    beta: half::f16,
+    c: &mut [half::f16],
+    ldc: i32,
+) {
+    ffi::hgemm_(
+        &(transa as c_char),
+        &(transb as c_char),
+        &m,
+        &n,
+        &k,
+        &alpha,
+        a.as_ptr(),
+        &lda,
+        b.as_ptr(),
+        &ldb,
+        &beta,
+        c.as_mut_ptr(),
+        &ldc,
+    )
+}


### PR DESCRIPTION
As mentioned in #41 it would be nice to have support for half precision matmul (especially when using mkl).
This PR adds it and goes together with https://github.com/blas-lapack-rs/blas-sys/pull/21 on the sys side. The blas-sys version has been bumped to reflect the new requirement.

Let me know if there is anything that could be done to improve this PR or the blas-sys one, or if you see any different way to get this working.
Thanks,

Note that this has been tested in a very simple way via the following:
```rust
extern crate intel_mkl_src;

use half::f16;

fn main() {
    println!("Hello, world!");
    let alpha = f16::ONE;
    let beta = f16::ZERO;
    let a = vec![f16::from_f64(0.5)];
    let b = vec![f16::from_f64(0.5)];
    let mut c = vec![f16::from_f64(0.5)];
    unsafe {
        blas::hgemm(
            b'N',
            b'N',
            1,
            1,
            1,
            alpha,
            a.as_slice(),
            1,
            b.as_slice(),
            1,
            beta,
            c.as_mut_slice(),
            42,
        )
    };
    println!("{c:?}");
}
```